### PR TITLE
统一使用手机端cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,13 @@
   * `phone_tail_number`: 手机后4位尾号，若填写将会校验店铺尾号是否是规定的，不符合就跳过
   * `member_close_max_number`: 设置本次运行注销的最大店铺数，默认为0，代表不限制
   * `mobile_cookie`: 手机端cookie，是pt_key开头的那个
-  * `users`: web端cookie，通过add_cookie.py添加
+  * `users`: 现在没有用了
 
 ### 3. 添加`cookie`
 
-* web端cookie：请在项目目录下执行`python3 add_cookie.py`， 在打开的浏览器界面登录你的京东，此时你可以看到`config.json`已经有了你的用户信息（**请不要随意泄露你的cookie**）
-* 手机端cookie：在 `config.json` 中写入 `mobile_cookie` 项，注意是pt_key开头的那个（**请不要随意泄露你的cookie**）
+-   使用`add_cookie.py`可以获取手机端`Cookie`
+
+* 在 `config.json` 中写入 `mobile_cookie` 项，注意是pt_key=123456;pt_pin=jd_987654的那个（**请不要随意泄露你的cookie**）
 
 ### 4. 启动 `jd_wstool` 工具（使用OCR的不用开）
 

--- a/add_cookie.py
+++ b/add_cookie.py
@@ -9,20 +9,24 @@ from selenium.common.exceptions import WebDriverException
 
 if __name__ == '__main__':
     """
-    用于获取web端cookie
+    用于获取手机端cookie
     """
     config = get_config()
     config['headless'] = False
     browser = get_browser(config)
-    browser.get("https://passport.jd.com/new/login.aspx")
+    browser.get("https://plogin.m.jd.com/login/login")
     try:
-        wait = WebDriverWait(browser, 35)
-        username = wait.until(EC.presence_of_element_located((By.CLASS_NAME, 'nickname'))).text
-        user = {
-            "userName": username,
-            "cookie": browser.get_cookies()
-        }
-        config['users'] = user
+        wait = WebDriverWait(browser, 135)
+        print("请在网页端通过手机号码登录")
+        wait.until(EC.presence_of_element_located((By.ID, 'msShortcutMenu')))
+        browser.get("https://home.m.jd.com/myJd/newhome.action")
+        username = wait.until(EC.presence_of_element_located((By.CLASS_NAME, 'my_header_name'))).text
+        cookie = ""
+        for _ in browser.get_cookies():
+            if _["name"] == "pt_key" or _["name"] == "pt_pin":
+                cookie += _["name"] + "=" + _["value"] + ";"
+        config['mobile_cookie'] = cookie[0:-1]
+        print("获取的cookie是：" + cookie)
         with open(get_file("./config.json"), mode='w', encoding="utf-8") as f:
             json.dump(config, f, indent=4, ensure_ascii=False)
         print("成功添加", username)

--- a/main.py
+++ b/main.py
@@ -131,16 +131,14 @@ class JDMemberCloseAccount(object):
             sys.exit(1)
 
         # 打开京东
-        self.browser.get("https://www.jd.com/")
-
+        self.browser.get("https://m.jd.com/")
+        # msShortcutLogin
         # 写入 cookie
-        for cookie in self.config['users']['cookie']:
-            cookie['domain'] = ".jd.com"
-            self.browser.add_cookie(cookie)
+        self.browser.delete_all_cookies()
+        for cookie in self.config['mobile_cookie'].split(";"):
+            self.browser.add_cookie({"name": cookie.split("=")[0], "value": cookie.split("=")[1], "domain": ".jd.com"})
         self.browser.refresh()
 
-        # 验证是否登录成功
-        self.wait.until(EC.presence_of_element_located((By.CLASS_NAME, 'nickname')))
         self.browser.set_window_size(500, 700)
 
         cache_brand_id, pc_cookie_valid, retried = "", True, 0

--- a/utils/selenium_browser.py
+++ b/utils/selenium_browser.py
@@ -14,7 +14,8 @@ def get_browser(_config):
     browser_type = _config['browserType']
     headless = _config['headless']
     binary = _config['binary']
-
+    user_agent = "Mozilla/5.0 (Linux; Android 9; COR-AL00) AppleWebKit/537.36 (KHTML, like Gecko) " \
+                 "Chrome/77.0.3865.116 Mobile Safari/537.36 EdgA/46.03.4.5155 "
     try:
         if browser_type == 'Chrome':
             chrome_options = webdriver.ChromeOptions()
@@ -22,6 +23,7 @@ def get_browser(_config):
             chrome_options.add_argument('--no-sandbox')
             chrome_options.add_argument('--disable-dev-shm-usage')
             chrome_options.add_experimental_option("excludeSwitches", ['enable-automation', 'enable-logging'])
+            chrome_options.add_argument(f'user-agent={user_agent}')
             if binary != "":
                 # 当找不到浏览器时需要在 config 里配置路径
                 chrome_options.binary_location = binary


### PR DESCRIPTION
统一使用手机端`cookie`,并将`add_cookie.py`改为获取手机端`cookie`

---
统一使用手机端的网页，可能网页的代码有所改变导致定位不准，可能有错误请查看