### PR TITLE
[dev]更改监听验证码为python模式, 运行脚本时直接启动

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,22 +13,23 @@ from captcha.jd_captcha import JDcaptcha_base64
 from utils.logger import Log
 from utils.config import get_config
 from utils.selenium_browser import get_browser
+from utils.listener import listener
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 
-async def ws_conn(ws_conn_url):
-    """
-    websocket连接
-    """
-    async with connect(ws_conn_url) as websocket:
-        try:
-            recv = await asyncio.wait_for(websocket.recv(), get_config()["sms_captcha"]["ws_timeout"])
-            return recv
-        except asyncio.TimeoutError:
-            return ""
+# async def ws_conn(ws_conn_url):
+#     """
+#     websocket连接
+#     """
+#     async with connect(ws_conn_url) as websocket:
+#         try:
+#             recv = await asyncio.wait_for(websocket.recv(), get_config()["sms_captcha"]["ws_timeout"])
+#             return recv
+#         except asyncio.TimeoutError:
+#             return ""
 
 
 logger = Log().logger
@@ -353,7 +354,8 @@ class JDMemberCloseAccount(object):
                                 sms_code = self.easy_ocr.easy_ocr(_range, ocr_delay_time)
                     else:
                         try:
-                            recv = asyncio.get_event_loop().run_until_complete(ws_conn(ws_conn_url))
+                            # recv = asyncio.get_event_loop().run_until_complete(ws_conn(ws_conn_url))
+                            recv = listener()
                             if recv == "":
                                 INFO("等待websocket推送短信验证码超时，即将跳过", card["brandName"])
                                 continue

--- a/test_main.py
+++ b/test_main.py
@@ -1,8 +1,9 @@
 import asyncio
 import json
 import sys
-
-from main import ws_conn
+import requests
+from utils.listener import listener
+from utils.listener import get_host_ip
 from utils.config import get_config
 
 
@@ -14,7 +15,8 @@ def test_websocket():
     print("开始测试websocket监听验证码转发")
     while True:
         try:
-            recv = asyncio.get_event_loop().run_until_complete(ws_conn(get_config()["sms_captcha"]["ws_conn_url"]))
+            print(f"短信验证码测试，请在手机上访问{get_host_ip()}:5201/publish?smsCode=123456测试连通性")
+            recv = listener()
             if recv != "":
                 sms_code = json.loads(recv)["sms_code"]
                 print("发送测试验证码", sms_code)

--- a/utils/listener.py
+++ b/utils/listener.py
@@ -1,0 +1,104 @@
+import json
+import re
+import sys
+import time
+import threading
+import socket
+
+
+def get_host_ip():
+    """
+    查询本机ip地址
+    :return: ip
+    """
+    try:
+        _ = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        _.connect(('1.2.3.4', 80))
+        ip = _.getsockname()[0]
+    finally:
+        _.close()
+        return ip
+
+
+class MyThread(threading.Thread):
+    def __init__(self, target, args=()):
+        """
+            因为threading类没有返回值,因此在此处重新定义MyThread类,使线程拥有返回值
+        """
+        super(MyThread, self).__init__()
+        self.func = target
+        self.args = args
+
+    def run(self):
+        # 接受返回值
+        self.result = self.func(*self.args)
+
+    def get_result(self):
+        # 线程不结束,返回值为None
+        try:
+            return self.result
+        except Exception:
+            return None
+
+
+def limit_decor(timeout, granularity):
+    """
+    timeout 最大允许执行时长, 单位:秒
+    granularity 轮询间隔，间隔越短结果越精确同时cpu负载越高
+    return 未超时返回被装饰函数返回值,超时则返回 None
+    """
+
+    def functions(func):
+        def run(*args):
+            thre_func = MyThread(target=func, args=args)
+            thre_func.setDaemon(True)
+            thre_func.start()
+            sleep_num = int(timeout // granularity)
+            for i in range(0, sleep_num):
+                infor = thre_func.get_result()
+                if infor:
+                    return infor
+                else:
+                    time.sleep(granularity)
+            return ""
+
+        return run
+
+    return functions
+
+
+try:
+    tcp_server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp_server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    tcp_server.bind(("", 5201))
+    tcp_server.listen(128)
+    font_color = ["\033[1;36m", "\033[0m"]
+    print(f"""{font_color[0] if sys.platform != "win32" else ""}注意事项：
+        1. 手机端请求IP地址为如下监听地址，请先用电脑点击一下哪个可以访问通！
+        2. 用手机浏览器测试访问说明1中尝试过的IP地址，如访问通代表无问题
+        3. 以下IP获取到的IP仅做参考，如果全部访问不通，请检查防火墙开启5201端口或使用ipconfig/ifconfig查看本地其他IP{font_color[1] if sys.platform != "win32" else ""}
+    """)
+    print(f"监听地址:\thttp://{get_host_ip()}:5201/\n其它的请 ipconfig/ifconfig 查看本地其他IP")
+except:
+    print("监听失败,请查看是否有同端口脚本")
+
+
+# 等待时间30 轮询时间0.5
+@limit_decor(30, 0.5)
+def listener(*args, **kwargs):
+    """
+    通过 socket 监听
+    """
+    try:
+        cs, ca = tcp_server.accept()
+        recv_data = cs.recv(1024)
+        a = str(re.search(r'smsCode=(\d+)', str(recv_data)).group(1))
+        print(f'{time.strftime("%Y/%m/%d %H:%M:%S", time.localtime())}\t监听到京东验证码:\t{a}')
+        return json.dumps({"sms_code": a})
+    except:
+        return ""
+
+
+if __name__ == '__main__':
+    while True:
+        print(listener())


### PR DESCRIPTION
更改使用`socket`监听短信验证码，可以在启动时直接运行
默认监听所有网卡`ip`但列出来的只有一个最可能的。

---
可能出现的问题
1. 端口可能会被占用
2. 只要是`?smsCode=***`结尾的请求都能被监听到