### PR TITLE
兼容新版edge

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ baidu-aip==2.2.18.0
 websockets~=9.1
 opencv_python~=4.5.2.54
 func-timeout~=4.3.5
+msedge-selenium-tools~=3.141.3


### PR DESCRIPTION
貌似新版edge还得安装一个第三方库才能调动，我这边试了下可以用edge了