### PR TITLE
disable compress on websocket client

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ async def ws_conn(ws_conn_url, ws_timeout):
     """
     websocket连接
     """
-    async with websockets.legacy.client.connect(ws_conn_url) as websocket:
+    async with websockets.legacy.client.connect(ws_conn_url, compression=None) as websocket:
         try:
             recv = await asyncio.wait_for(websocket.recv(), ws_timeout)
             return recv


### PR DESCRIPTION
fix `failed to accept WebSocket connection: unsupported permessage-deflate parameter: "server_max_window_bits=12"` on golang websocket server